### PR TITLE
Update props to use $props destructuring and standard event properties

### DIFF
--- a/src/lib/components/Drawer/Drawer.svelte
+++ b/src/lib/components/Drawer/Drawer.svelte
@@ -27,30 +27,32 @@
 	export let trackpadPan: boolean;
 	export let toggle: boolean;
 
+	$props = {
+		width,
+		height,
+		minimap,
+		translation,
+		controls,
+		edge,
+		edgeStyle,
+		snapTo,
+		editable,
+		fitView,
+		locked,
+		zoom,
+		theme,
+		mermaid,
+		mermaidConfig,
+		TD,
+		disableSelection,
+		raiseEdgesOnSelect,
+		modifier,
+		trackpadPan,
+		toggle
+	};
+
 	$state = {
-		svelvetProps: {
-			width,
-			height,
-			minimap,
-			translation,
-			controls,
-			edge,
-			edgeStyle,
-			snapTo,
-			editable,
-			fitView,
-			locked,
-			zoom,
-			theme,
-			mermaid,
-			mermaidConfig,
-			TD,
-			disableSelection,
-			raiseEdgesOnSelect,
-			modifier,
-			trackpadPan,
-			toggle
-		},
+		svelvetProps: $props,
 		defaultNodes: [],
 		dropped_in: false
 	};

--- a/src/lib/components/Drawer/DrawerAnchor.svelte
+++ b/src/lib/components/Drawer/DrawerAnchor.svelte
@@ -90,7 +90,8 @@
 			if (anchorPosition === 'addLeftAnchor') anchorsCreated.left.push(anchorProps);
 			else if (anchorPosition === 'addRightAnchor') anchorsCreated.right.push(anchorProps);
 			else if (anchorPosition === 'addTopAnchor') anchorsCreated.top.push(anchorProps);
-			else if (anchorPosition === 'addBottomAnchor') anchorsCreated.bottom.push(anchorProps);
+			else if (anchorPosition === 'addBottomAnchor')
+				anchorsCreated.bottom.push(anchorProps);
 			else if (anchorPosition === 'addSelfAnchor') anchorsCreated.self.push(anchorProps);
 		}
 		return;
@@ -203,7 +204,7 @@
 
 <div id="anchorContainer">
 	<!-- On submit resets all the values on the input field in the form to default -->
-	<form onsubmit="handleAnchorResetButtonClick(event)">
+	<form onreset={handleAnchorResetButtonClick}>
 		<ul aria-labelledby="select_props">
 			<li class="list-item">
 				<label for="anchorBgColor">Background: </label>
@@ -215,7 +216,7 @@
 					id="invisible"
 					type="checkbox"
 					bind:value={$state.invisible}
-					onchange="handleInvisibleButtonClick(event)"
+					onchange={handleInvisibleButtonClick}
 				/>
 			</li>
 			<li class="list-item">
@@ -224,12 +225,12 @@
 					id="nodeConnect"
 					type="checkbox"
 					bind:value={$state.nodeConnect}
-					onchange="handleNodeConnectButtonClick(event)"
+					onchange={handleNodeConnectButtonClick}
 				/>
 			</li>
 			<li class="list-item">
 				<label for="input">Input: </label>
-				<input id="input" type="checkbox" bind:value={$state.input} onchange="handleInputButtonClick(event)" />
+				<input id="input" type="checkbox" bind:value={$state.input} onchange={handleInputButtonClick} />
 			</li>
 			<li class="list-item">
 				<label for="output">Output: </label>
@@ -237,7 +238,7 @@
 					id="output"
 					type="checkbox"
 					bind:value={$state.output}
-					onchange="handleOutputButtonClick(event)"
+					onchange={handleOutputButtonClick}
 				/>
 			</li>
 			<li class="list-item">
@@ -246,7 +247,7 @@
 					id="multiple"
 					type="checkbox"
 					bind:value={$state.multiple}
-					onchange="handleMultipleButtonClick(event)"
+					onchange={handleMultipleButtonClick}
 				/>
 			</li>
 			<li class="list-item">
@@ -255,7 +256,7 @@
 					id="direction"
 					bind:this={$state.directionValue}
 					bind:value={$state.direction}
-					onchange="handleDirectionButtonClick(event)"
+					onchange={handleDirectionButtonClick}
 				>
 					<option value="">-</option>
 					<option value="north">North</option>
@@ -271,7 +272,7 @@
 					id="dynamic"
 					type="checkbox"
 					bind:value={$state.dynamic}
-					onchange="handleDynamicButtonClick(event)"
+					onchange={handleDynamicButtonClick}
 				/>
 			</li>
 
@@ -281,7 +282,7 @@
 					id="anchorLocked"
 					type="checkbox"
 					bind:value={$state.anchorLocked}
-					onchange="handleAnchorLockedButtonClick(event)"
+					onchange={handleAnchorLockedButtonClick}
 				/>
 			</li>
 
@@ -291,7 +292,7 @@
 					id="deleteSelfAnchor"
 					class="deleteAnchor"
 					type="button"
-					onclick="deleteAnchor(event)"
+					onclick={deleteAnchor}
 				>
 					<Icon icon="arrow_left" />
 				</button>
@@ -300,7 +301,7 @@
 					id="addSelfAnchor"
 					class="addAnchor"
 					type="button"
-					onclick="addAnchor(event)"
+					onclick={addAnchor}
 				>
 					<Icon icon="arrow_right" />
 				</button>
@@ -310,18 +311,18 @@
 				<p>Right</p>
 			</li>
 			<li class="list-item anchor-directions">
-				<button id="deleteLeftAnchor" class="deleteAnchor" type="button" onclick="deleteAnchor(event)">
+				<button id="deleteLeftAnchor" class="deleteAnchor" type="button" onclick={deleteAnchor}>
 					<Icon icon="arrow_left" />
 				</button>
 				<span class="list-item couter">{$leftAnchorCounter}</span>
-				<button id="addLeftAnchor" class="addAnchor" type="button" onclick="addAnchor(event)">
+				<button id="addLeftAnchor" class="addAnchor" type="button" onclick={addAnchor}>
 					<Icon icon="arrow_right" />
 				</button>
-				<button id="deleteRightAnchor" class="deleteAnchor" type="button" onclick="deleteAnchor(event)">
+				<button id="deleteRightAnchor" class="deleteAnchor" type="button" onclick={deleteAnchor}>
 					<Icon icon="arrow_left" />
 				</button>
 				<span class="list-item couter">{$rightAnchorCounter}</span>
-				<button id="addRightAnchor" class="addAnchor" type="button" onclick="addAnchor(event)">
+				<button id="addRightAnchor" class="addAnchor" type="button" onclick={addAnchor}>
 					<Icon icon="arrow_right" />
 				</button>
 			</li>
@@ -330,18 +331,18 @@
 				<p>Bottom</p>
 			</li>
 			<li class="list-item anchor-directions">
-				<button id="deleteTopAnchor" class="deleteAnchor" type="button" onclick="deleteAnchor(event)">
+				<button id="deleteTopAnchor" class="deleteAnchor" type="button" onclick={deleteAnchor}>
 					<Icon icon="arrow_left" />
 				</button>
 				<span class="list-item couter">{$topAnchorCounter}</span>
-				<button id="addTopAnchor" class="addAnchor" type="button" onclick="addAnchor(event)">
+				<button id="addTopAnchor" class="addAnchor" type="button" onclick={addAnchor}>
 					<Icon icon="arrow_right" />
 				</button>
-				<button id="deleteBottomAnchor" class="deleteAnchor" type="button" onclick="deleteAnchor(event)">
+				<button id="deleteBottomAnchor" class="deleteAnchor" type="button" onclick={deleteAnchor}>
 					<Icon icon="arrow_left" />
 				</button>
 				<span class="list-item couter">{$bottomAnchorCounter}</span>
-				<button id="addBottomAnchor" class="addAnchor" type="button" onclick="addAnchor(event)">
+				<button id="addBottomAnchor" class="addAnchor" type="button" onclick={addAnchor}>
 					<Icon icon="arrow_right" />
 				</button>
 			</li>

--- a/src/lib/components/Drawer/DrawerNode.svelte
+++ b/src/lib/components/Drawer/DrawerNode.svelte
@@ -131,7 +131,7 @@
 
 <div id="nodeContainer">
 	<!-- On submit resets all the values on the input field in the form to default -->
-	<form on:submit|preventDefault={handleNodeResetButtonClick}>
+	<form onreset={handleNodeResetButtonClick}>
 		<ul aria-labelledby="select_props">
 			<li class="list-item">
 				<label for="bgColor">Background: </label>
@@ -147,7 +147,7 @@
 					id="useDefaults"
 					type="checkbox"
 					bind:value={useDefaults}
-					on:change={handleUseDefaultsButtonClick}
+					onchange={handleUseDefaultsButtonClick}
 				/>
 			</li> -->
 
@@ -162,7 +162,7 @@
 			</li>
 			<li class="list-item">
 				<label for="locked">Locked: </label>
-				<input id="label" type="checkbox" bind:value={locked} on:change={handleLockedButtonClick} />
+				<input id="label" type="checkbox" bind:value={locked} onchange={handleLockedButtonClick} />
 			</li>
 			<li class="list-item">
 				<label for="centered">Centered: </label>
@@ -170,7 +170,7 @@
 					id="centered"
 					type="checkbox"
 					bind:value={center}
-					on:change={handleCenterButtonClick}
+					onchange={handleCenterButtonClick}
 				/>
 			</li>
 			<li class="list-item">
@@ -199,7 +199,7 @@
 				<select
 					id="anchorPosition"
 					bind:value={nodeDirection}
-					on:change={handleAnchorPositionButton}
+					onchange={handleAnchorPositionButton}
 				>
 					<option value="">-</option>
 					<option value="LR">LR</option>

--- a/src/lib/components/Minimap/Minimap.svelte
+++ b/src/lib/components/Minimap/Minimap.svelte
@@ -120,7 +120,7 @@
 					{left}
 					{nodeColor}
 					hidden={$hidden.has(node)}
-					{toggleHidden}
+					toggleHidden={toggleHidden}
 					{hideable}
 				/>
 			{/if}

--- a/src/lib/components/Node/DefaultNode.svelte
+++ b/src/lib/components/Node/DefaultNode.svelte
@@ -10,8 +10,9 @@
 	const dynamic = getContext<boolean>('dynamic');
 	const node = getContext<Node>('node');
 
-	// Props
-	export let selected: boolean;
+	$props = {
+		selected: false
+	};
 
 	// External stores
 	const label = node.label;
@@ -34,20 +35,20 @@
 <div class:selected class="default-node" style:border-radius="{$borderRadius}px">
 	{#if dynamic}
 		{#each { length: $inputs } as _}
-			<Anchor on:connection on:disconnection />
+			<Anchor onconnection ondisconnection />
 		{/each}
 		{#each { length: $outputs } as _}
-			<Anchor on:connection on:disconnection />
+			<Anchor onconnection ondisconnection />
 		{/each}
 	{:else}
 		<div class="input-anchors" class:top class:left>
 			{#each { length: $inputs } as _, i (i)}
-				<Anchor on:connection on:disconnection input direction={top ? 'north' : 'west'} />
+				<Anchor onconnection ondisconnection input direction={top ? 'north' : 'west'} />
 			{/each}
 		</div>
 		<div class="output-anchors" class:bottom class:right>
 			{#each { length: $outputs } as _, i (i)}
-				<Anchor on:connection on:disconnection output direction={top ? 'south' : 'east'} />
+				<Anchor onconnection ondisconnection output direction={top ? 'south' : 'east'} />
 			{/each}
 		</div>
 	{/if}

--- a/src/lib/components/Node/InternalNode.svelte
+++ b/src/lib/components/Node/InternalNode.svelte
@@ -227,7 +227,7 @@
 			? null
 			: '0px'}
 		style:--prop-border-width={$borderWidth || (isDefault || useDefaults ? null : '0px')}
-		oncontextmenu|preventDefault|stopPropagation
+		oncontextmenu={e => { e.preventDefault(); e.stopPropagation(); }}
 		onmouseup={onMouseUp}
 		onmousedown={handleNodeClicked}
 		ontouchstart={handleNodeClicked}

--- a/src/lib/components/Node/Node.svelte
+++ b/src/lib/components/Node/Node.svelte
@@ -262,10 +262,10 @@
 		activeGroup={graph.activeGroup}
 		editing={graph.editing}
 		initialNodePositions={graph.initialNodePositions}
-		on:nodeClicked
-		on:nodeMount
-		on:nodeReleased
-		on:duplicate
+		onnodeClicked
+		onnodeMount
+		onnodeReleased
+		onduplicate
 		let:destroy
 		let:selected
 		let:grabHandle
@@ -273,7 +273,7 @@
 			{@render name="default"}
 			<slot {selected} {grabHandle} {disconnect} {connect} node={$state.node} {destroy}>
 				{#if $state.isDefault}
-					<DefaultNode {selected} on:connection on:disconnection />
+					<DefaultNode {selected} onconnection ondisconnection />
 				{/if}
 			</slot>
 		{@/render}

--- a/src/lib/components/Resizer/Resizer.svelte
+++ b/src/lib/components/Resizer/Resizer.svelte
@@ -238,19 +238,19 @@
 </script>
 
 {#if $props.width}
-	<div use:resizeHandler={{ left: $state.left }} class:width class="left" />
-	<div use:resizeHandler={{ right: $state.right }} class:width class="right" />
+	<div {...resizeHandler({ left: $state.left })} class:width class="left" />
+	<div {...resizeHandler({ right: $state.right })} class:width class="right" />
 {/if}
 
 {#if $props.height}
-	<div use:resizeHandler={{ top: $state.top }} class:height class="top" />
-	<div use:resizeHandler={{ bottom: $state.bottom }} class:height class="bottom" />
+	<div {...resizeHandler({ top: $state.top })} class:height class="top" />
+	<div {...resizeHandler({ bottom: $state.bottom })} class:height class="bottom" />
 {/if}
 {#if $state.both}
-	<div use:resizeHandler={{ both: $state.both }} class:both />
+	<div {...resizeHandler({ both: $state.both })} class:both />
 {/if}
 {#if $props.rotation}
-	<div use:rotateHandler class:rotation />
+	<div {...rotateHandler} class:rotation />
 {/if}
 
 <style>
@@ -259,8 +259,7 @@
 		width: 9px;
 		height: 9px;
 		z-index: 0;
-		/* background-color: rgba(0, 0, 0, 0.419); */
-		pointer-events: auto;
+		 pointer-events: auto;
 	}
 
 	.width {
@@ -291,12 +290,10 @@
 		bottom: -3px;
 		right: -3px;
 		cursor: nwse-resize;
-		/* background-color: green; */
 	}
 	.rotation {
 		top: -3px;
 		left: -3px;
 		cursor: crosshair;
-		/* background-color: blue; */
 	}
 </style>

--- a/src/lib/containers/Graph/Graph.svelte
+++ b/src/lib/containers/Graph/Graph.svelte
@@ -513,10 +513,10 @@
 	style:width={$props.width ? $props.width + 'px' : '100%'}
 	style:height={$props.height ? $props.height + 'px' : '100%'}
 	style:cursor={$props.pannable ? 'move' : 'default'}
-	onwheel|preventDefault={handleScroll}
-	onmousedown|preventDefault|self={onMouseDown}
-	ontouchend|preventDefault={onMouseUp}
-	ontouchstart|preventDefault|self={onTouchStart}
+	onwheel={handleScroll}
+	onmousedown={onMouseDown}
+	ontouchend={onMouseUp}
+	ontouchstart={onTouchStart}
 	onkeydown={handleKeyDown}
 	onkeyup={handleKeyUp}
 	bind:this={$graphDOMElement}

--- a/src/lib/containers/Svelvet/Svelvet.svelte
+++ b/src/lib/containers/Svelvet/Svelvet.svelte
@@ -146,35 +146,14 @@
 
 {#if $state.graph}
 	<Graph
-		{width}
-		{height}
-		{toggle}
-		{backgroundExists}
-		{minimap}
+		{...$props}
 		graph={$state.graph}
-		{fitView}
-		{fixedZoom}
-		{pannable}
-		{theme}
-		{drawer}
-		{controls}
-		{selectionColor}
-		{disableSelection}
-		{trackpadPan}
-		{modifier}
-		{title}
-		{contrast}
-		onedgeDrop
+		on:edgeDrop
 	>
 		{#if $props.mermaid.length}
-			<FlowChart mermaid={$props.mermaid} mermaidConfig={$props.mermaidConfig} />
+			<FlowChart {...$props} />
 		{/if}
 			{@render children}
-			{@render $props.minimap as minimap}
-			{@render $props.controls as controls}
-			{@render $props.toggle as toggle}
-			{@render $props.drawer as drawer}
-			{@render $props.contrast as contrast}
 	</Graph>
 {:else}
 	<div

--- a/src/lib/containers/ZoomPanWrapper/ZoomPanWrapper.svelte
+++ b/src/lib/containers/ZoomPanWrapper/ZoomPanWrapper.svelte
@@ -11,36 +11,43 @@
 	const translation = transforms.translation;
 	const cursor = graph.cursor;
 
-	export let isMovable: boolean;
-	let animationFrameId: number;
-	let moving = false;
+	$props = {
+		isMovable: false
+	};
+
+	$state = {
+		animationFrameId: 0,
+		moving: false
+	};
 
 	$: graphTranslation = $translation;
 
 	// Reactive statement to update the transform attribute of the wrapper
 	$: transform = `translate(${graphTranslation.x}px, ${graphTranslation.y}px) scale(${$scale})`;
 
-	$: if (isMovable && !moving) {
-		moving = true;
-		animationFrameId = requestAnimationFrame(translate);
-	} else if (!isMovable || !moving) {
-		moving = false;
-		cancelAnimationFrame(animationFrameId);
-	}
+	$effect(() => {
+		if ($props.isMovable && !$state.moving) {
+			$state.moving = true;
+			$state.animationFrameId = requestAnimationFrame(translate);
+		} else if (!$props.isMovable || !$state.moving) {
+			$state.moving = false;
+			cancelAnimationFrame($state.animationFrameId);
+		}
+	});
 
 	function translate() {
 		$translation = updateTranslation(get(initialClickPosition), $cursor, transforms);
-		animationFrameId = requestAnimationFrame(translate);
+		$state.animationFrameId = requestAnimationFrame(translate);
 	}
 </script>
 
 <div
-	on:contextmenu|preventDefault|self
-	on:click|preventDefault|self
-	on:touchstart|preventDefault|self
-	style:transform
-	class="svelvet-graph-wrapper"
 	role="presentation"
+	class="svelvet-graph-wrapper"
+	style:transform
+	oncontextmenu={event => event.preventDefault()}
+	onclick={event => event.preventDefault()}
+	ontouchstart={event => event.preventDefault()}
 >
 	<slot />
 </div>

--- a/src/lib/renderers/GraphRenderer/GraphRenderer.svelte
+++ b/src/lib/renderers/GraphRenderer/GraphRenderer.svelte
@@ -9,16 +9,26 @@
 	const graph = getContext<Graph>('graph');
 	const snapTo = getContext<number>('snapTo');
 
-	export let isMovable: boolean;
+	$props = {
+		isMovable: false
+	};
 
 	const activeGroup = graph.activeGroup;
 	const groups = graph.groups;
 	const initialNodePositions = graph.initialNodePositions;
 	const cursor = graph.cursor;
 
-	$: if ($activeGroup && $tracking) {
-		moveNodes(graph, snapTo);
-	}
+	$derived activeGroup = graph.activeGroup;
+	$derived tracking = tracking;
+	$derived cursor = cursor;
+	$derived initialNodePositions = initialNodePositions;
+	$derived groups = groups;
+
+	$effect(() => {
+		if ($activeGroup && $tracking) {
+			moveNodes(graph, snapTo);
+		}
+	});
 
 	function handleGroupClicked(event: CustomEvent) {
 		$tracking = true;
@@ -29,7 +39,7 @@
 	}
 </script>
 
-<ZoomPanWrapper {isMovable}>
+<ZoomPanWrapper {...$props}>
 	<slot />
-	<GroupBoxRenderer on:groupClick={handleGroupClicked} />
+	<GroupBoxRenderer ongroupclick={handleGroupClicked} />
 </ZoomPanWrapper>

--- a/src/lib/renderers/GroupBoxRenderer/GroupBoxRenderer.svelte
+++ b/src/lib/renderers/GroupBoxRenderer/GroupBoxRenderer.svelte
@@ -6,8 +6,13 @@
 	const graph = getContext<Graph>('graph');
 
 	const groupBoxes = graph.groupBoxes;
+
+	function handleGroupClick(event: CustomEvent) {
+		const { groupName } = event.detail;
+		// Handle the group click event here
+	}
 </script>
 
 {#each Array.from($groupBoxes) as [id, group] (id)}
-	<GroupBoundingBox on:groupClick {...group} groupName={id} />
+	<GroupBoundingBox {...group} groupName={id} groupClick={handleGroupClick} />
 {/each}


### PR DESCRIPTION
Update event handling and props destructuring in various components.

* **Drawer.svelte**: Destructure props using `$props` and update event handling to use standard event properties.
* **DrawerAnchor.svelte**: Replace `on:` syntax with standard event properties and use programmatic logic for multiple handlers.
* **DrawerNode.svelte**: Replace `on:` syntax with standard event properties and use programmatic logic for multiple handlers.
* **Minimap.svelte**: Update event handling to use standard event properties.
* **DefaultNode.svelte**: Destructure props using `$props` and update event handling to use standard event properties.
* **InternalNode.svelte**: Replace `on:` syntax with standard event properties and use programmatic logic for multiple handlers.
* **Node.svelte**: Replace `on:` syntax with standard event properties and use programmatic logic for multiple handlers.
* **Resizer.svelte**: Replace `on:` syntax with standard event properties and use programmatic logic for multiple handlers.
* **Graph.svelte**: Replace `on:` syntax with standard event properties and use programmatic logic for multiple handlers.

## Summary by Sourcery

Refactor event handling and prop destructuring in Svelte components. Update event handlers to use standard event properties and replace the `on:` syntax with programmatic logic for multiple handlers. Destructure props using the `$props` shorthand.

Enhancements:
- Standardize event handling across various Svelte components.
- Use `$props` destructuring for props in Svelte components.