### PR TITLE
Upgrade to Svelte 5

### DIFF
--- a/src/example-components/Connector.svelte
+++ b/src/example-components/Connector.svelte
@@ -2,10 +2,10 @@
 	import { Svelvet, Node, Anchor } from '$lib';
 	import { getContext } from 'svelte';
 	function addAndConnect(connect: (connections: string | number) => void) {
-		connect(totalNodes + 4);
-		totalNodes++;
+		connect($state.totalNodes + 4);
+		$state.totalNodes++;
 	}
-	let totalNodes = 0;
+	$state.totalNodes = 0;
 </script>
 
 <Node

--- a/src/example-components/CustomEdge.svelte
+++ b/src/example-components/CustomEdge.svelte
@@ -2,8 +2,8 @@
 	import Edge from '$lib/components/Edge/Edge.svelte';
 	import type { CSSColorString } from '$lib/types';
 
-	let color: CSSColorString = 'yellow';
-	let edge: Edge = $state();
+	$state.color: CSSColorString = 'yellow';
+	$state.edge: Edge = $state();
 </script>
 
 <Edge

--- a/src/example-components/CustomNode.svelte
+++ b/src/example-components/CustomNode.svelte
@@ -2,7 +2,7 @@
 	import { Node, Anchor, Slider } from '$lib';
 	import { writable } from 'svelte/store';
 
-	const parameter = writable(10);
+	$state.parameter = writable(10);
 </script>
 
 <Node>
@@ -11,8 +11,8 @@
 			<Slider parameterStore={parameter} />
 			<div class="input-anchors">
 				<Anchor
-					on:disconnection={() => console.log('disconnection')}
-					on:connection={() => console.log('connection')}
+					ondisconnection={() => console.log('disconnection')}
+					onconnection={() => console.log('connection')}
 					input
 					id="1"
 				/>

--- a/src/example-components/InputNode.svelte
+++ b/src/example-components/InputNode.svelte
@@ -1,39 +1,46 @@
 <script lang="ts">
 	import { Anchor, Node } from '$lib';
 
-	let text = $state('Test');
-	let checked = $state(true);
-	let color = $state('#ff0000');
-	let date = $state(new Date());
-	let datetime = $state(new Date());
-	let email = $state('');
-	let month = $state('');
-	let number = $state(0);
-	let password = $state('');
-	let radio = $state('');
-	let range = $state(0);
-	let search = $state('');
-	let tel = $state('');
-	let url = '';
-	let week = '';
+	$state.text = 'Test';
+	$state.checked = true;
+	$state.color = '#ff0000';
+	$state.date = new Date();
+	$state.datetime = new Date();
+	$state.email = '';
+	$state.month = '';
+	$state.number = 0;
+	$state.password = '';
+	$state.radio = '';
+	$state.range = 0;
+	$state.search = '';
+	$state.tel = '';
+	$state.url = '';
+	$state.week = '';
+
+	$derived formattedDate = $state.date.toLocaleDateString();
+	$derived formattedDatetime = $state.datetime.toLocaleString();
+
+	$effect(() => {
+		console.log('Text changed:', $state.text);
+	});
 </script>
 
 <Node id="input" bgColor="black" label="StartNode" borderRadius={10} >
-	{#snippet children({ destroy })}
+	{@render children({ destroy })}
 		<div class="node">
-			<input id="text-test" type="text" bind:value={text} />
-			<input id="checkbox-test" type="checkbox" bind:checked />
-			<input type="color" bind:value={color} />
-			<input type="date" bind:value={date} />
-			<input type="datetime-local" bind:value={datetime} />
-			<input type="email" bind:value={email} />
-			<input type="month" bind:value={month} />
-			<input type="number" bind:value={number} />
-			<input type="password" bind:value={password} />
-			<input type="radio" bind:value={radio} />
-			<input type="range" bind:value={range} />
-			<input type="search" bind:value={search} />
-			<input type="tel" bind:value={tel} />
+			<input id="text-test" type="text" bind:value={$state.text} />
+			<input id="checkbox-test" type="checkbox" bind:checked={$state.checked} />
+			<input type="color" bind:value={$state.color} />
+			<input type="date" bind:value={$state.date} />
+			<input type="datetime-local" bind:value={$state.datetime} />
+			<input type="email" bind:value={$state.email} />
+			<input type="month" bind:value={$state.month} />
+			<input type="number" bind:value={$state.number} />
+			<input type="password" bind:value={$state.password} />
+			<input type="radio" bind:value={$state.radio} />
+			<input type="range" bind:value={$state.range} />
+			<input type="search" bind:value={$state.search} />
+			<input type="tel" bind:value={$state.tel} />
 			<select id="numberSelect">
 				<option value="1">1</option>
 				<option value="2">2</option>
@@ -47,9 +54,9 @@
 				<option value="10">10</option>
 			</select>
 			<textarea id="textarea-test"></textarea>
-			<button onclick={destroy}>Test</button>
+			<button onclick={$state.destroy}>Test</button>
 		</div>
-	{/snippet}
+	{@/render}
 </Node>
 
 <style>

--- a/src/lib/components/Drawer/DrawerEdge.svelte
+++ b/src/lib/components/Drawer/DrawerEdge.svelte
@@ -8,17 +8,17 @@
 	import { addProps } from '$lib/utils';
 
 	//types for edge creation
-	let edgeWidth: number | undefined;
-	let color: CSSColorString | undefined;
-	let straight: boolean | undefined; // Stretch feature, requires additional logic
-	let step: boolean | undefined;
-	let cornerRadius: number | undefined;
-	let animate: boolean | undefined;
-	let edgeLabel: string | undefined;
-	let labelColor: CSSColorString | undefined;
-	let textColor: CSSColorString | undefined;
-	// let edgeClick: () => void | null; // Stretch feature, needs edgeClick to function
-	let targetColor: CSSColorString | undefined; // Stretch feature, needs edgeClick to function
+	$state.edgeWidth = undefined;
+	$state.color = undefined;
+	$state.straight = undefined; // Stretch feature, requires additional logic
+	$state.step = undefined;
+	$state.cornerRadius = undefined;
+	$state.animate = undefined;
+	$state.edgeLabel = undefined;
+	$state.labelColor = undefined;
+	$state.textColor = undefined;
+	// $state.edgeClick = null; // Stretch feature, needs edgeClick to function
+	$state.targetColor = undefined; // Stretch feature, needs edgeClick to function
 
 	export function createEdgeProps() {
 		// Object that stores properties for the created edge
@@ -37,16 +37,16 @@
 			'textColor'
 		];
 		const edgePropsArray: EdgeProps = [
-			edgeWidth,
-			targetColor,
-			color,
-			straight,
-			step,
-			cornerRadius,
-			animate,
-			edgeLabel,
-			labelColor,
-			textColor
+			 $state.edgeWidth,
+			 $state.targetColor,
+			 $state.color,
+			 $state.straight,
+			 $state.step,
+			 $state.cornerRadius,
+			 $state.animate,
+			 $state.edgeLabel,
+			 $state.labelColor,
+			 $state.textColor
 		];
 
 		// Add props to edge if they exist
@@ -59,24 +59,24 @@
 
 	const handleStepButtonClick = (e: Event) => {
 		const target = e.target as HTMLInputElement;
-		step = target.checked;
+		 $state.step = target.checked;
 	};
 	const handleAnimateButtonClick = (e: Event) => {
 		const target = e.target as HTMLInputElement;
-		animate = target.checked;
+		 $state.animate = target.checked;
 	};
 
 	const handleEdgeResetButtonClick = (e: Event) => {
-		edgeWidth = undefined;
-		targetColor = undefined;
-		color = undefined;
-		straight = undefined;
-		step = undefined;
-		cornerRadius = undefined;
-		animate = undefined;
-		edgeLabel = undefined;
-		labelColor = undefined;
-		textColor = undefined;
+		 $state.edgeWidth = undefined;
+		 $state.targetColor = undefined;
+		 $state.color = undefined;
+		 $state.straight = undefined;
+		 $state.step = undefined;
+		 $state.cornerRadius = undefined;
+		 $state.animate = undefined;
+		 $state.edgeLabel = undefined;
+		 $state.labelColor = undefined;
+		 $state.textColor = undefined;
 		//edgeClick: () => void | null;
 		const target = e.target as HTMLFormElement;
 		target.reset();
@@ -84,34 +84,34 @@
 
 	// Validation for edge properties
 	const validateEdgeProps = () => {
-		if (edgeWidth !== undefined && typeof edgeWidth !== 'number') {
+		if ( $state.edgeWidth !== undefined && typeof  $state.edgeWidth !== 'number') {
 			throw new Error('Invalid value for edgeWidth property');
 		}
-		if (color !== undefined && typeof color !== 'string') {
+		if ( $state.color !== undefined && typeof  $state.color !== 'string') {
 			throw new Error('Invalid value for color property');
 		}
-		if (straight !== undefined && typeof straight !== 'boolean') {
+		if ( $state.straight !== undefined && typeof  $state.straight !== 'boolean') {
 			throw new Error('Invalid value for straight property');
 		}
-		if (step !== undefined && typeof step !== 'boolean') {
+		if ( $state.step !== undefined && typeof  $state.step !== 'boolean') {
 			throw new Error('Invalid value for step property');
 		}
-		if (cornerRadius !== undefined && typeof cornerRadius !== 'number') {
+		if ( $state.cornerRadius !== undefined && typeof  $state.cornerRadius !== 'number') {
 			throw new Error('Invalid value for cornerRadius property');
 		}
-		if (animate !== undefined && typeof animate !== 'boolean') {
+		if ( $state.animate !== undefined && typeof  $state.animate !== 'boolean') {
 			throw new Error('Invalid value for animate property');
 		}
-		if (edgeLabel !== undefined && typeof edgeLabel !== 'string') {
+		if ( $state.edgeLabel !== undefined && typeof  $state.edgeLabel !== 'string') {
 			throw new Error('Invalid value for edgeLabel property');
 		}
-		if (labelColor !== undefined && typeof labelColor !== 'string') {
+		if ( $state.labelColor !== undefined && typeof  $state.labelColor !== 'string') {
 			throw new Error('Invalid value for labelColor property');
 		}
-		if (textColor !== undefined && typeof textColor !== 'string') {
+		if ( $state.textColor !== undefined && typeof  $state.textColor !== 'string') {
 			throw new Error('Invalid value for textColor property');
 		}
-		if (targetColor !== undefined && typeof targetColor !== 'string') {
+		if ( $state.targetColor !== undefined && typeof  $state.targetColor !== 'string') {
 			throw new Error('Invalid value for targetColor property');
 		}
 	};
@@ -123,40 +123,40 @@
 		<ul aria-labelledby="select_props">
 			<li class="list-item">
 				<label for="color">Background: </label>
-				<input id="color" class="colorWheel" type="color" bind:value={color} />
+				<input id="color" class="colorWheel" type="color" bind:value={$state.color} />
 			</li>
 			<li class="list-item">
 				<label for="labelColor">Label: </label>
-				<input id="labelColor" class="colorWheel" type="color" bind:value={labelColor} />
+				<input id="labelColor" class="colorWheel" type="color" bind:value={$state.labelColor} />
 			</li>
 			<li class="list-item">
 				<label for="textColor">Text: </label>
-				<input id="textColor" class="colorWheel" type="color" bind:value={textColor} />
+				<input id="textColor" class="colorWheel" type="color" bind:value={$state.textColor} />
 			</li>
 			<li class="list-item">
 				<label for="animate">Animate : </label>
 				<input
 					id="animate"
 					type="checkbox"
-					bind:value={animate}
+					bind:value={$state.animate}
 					onchange={handleAnimateButtonClick}
 				/>
 			</li>
 			<li class="list-item">
 				<label for="step">Step: </label>
-				<input id="step" type="checkbox" bind:value={step} onchange={handleStepButtonClick} />
+				<input id="step" type="checkbox" bind:value={$state.step} onchange={handleStepButtonClick} />
 			</li>
 			<li class="list-item">
 				<label for="cornerRadius">Corner Radius:</label>
-				<input id="cornerRadius" class="inputField" type="number" bind:value={cornerRadius} />
+				<input id="cornerRadius" class="inputField" type="number" bind:value={$state.cornerRadius} />
 			</li>
 			<li class="list-item">
 				<label for="width">Width:</label>
-				<input id="width" class="inputField" type="number" bind:value={edgeWidth} />
+				<input id="width" class="inputField" type="number" bind:value={$state.edgeWidth} />
 			</li>
 			<li class="list-item">
 				<label for="edgeLabel">Edge Label: </label>
-				<input id="edgeLabel" type="text" bind:value={edgeLabel} />
+				<input id="edgeLabel" type="text" bind:value={$state.edgeLabel} />
 			</li>
 			<li class="list-item">
 				<button class="edgeResetBtn btn" aria-label="Reset">Reset</button>

--- a/src/lib/components/Drawer/DrawerNode.svelte
+++ b/src/lib/components/Drawer/DrawerNode.svelte
@@ -13,21 +13,21 @@
 	export const defaultNodePropsStore = writable<Array<NodeDrawerConfig>>([]);
 
 	// types for node creation
-	let bgColor: CSSColorString | undefined;
-	let borderColor: CSSColorString | undefined;
-	let label: string | undefined;
-	let width = 200;
-	let height = 100;
-	let locked: boolean | undefined;
-	let center: boolean | undefined;
-	let inputs: number | undefined;
-	let outputs: number | undefined;
-	let rotation: number | undefined;
-	let zIndex: number | undefined;
-	let TD: boolean | undefined;
-	let LR: boolean | undefined;
-	let useDefaults: boolean | undefined;
-	let nodeDirection: string | undefined;
+	$state.bgColor = undefined;
+	$state.borderColor = undefined;
+	$state.label = undefined;
+	$state.width = 200;
+	$state.height = 100;
+	$state.locked = undefined;
+	$state.center = undefined;
+	$state.inputs = undefined;
+	$state.outputs = undefined;
+	$state.rotation = undefined;
+	$state.zIndex = undefined;
+	$state.TD = undefined;
+	$state.LR = undefined;
+	$state.useDefaults = undefined;
+	$state.nodeDirection = undefined;
 
 	// Creates props and adds to customNodePropsStore if an anchor was created, defaultNodePropsStore if not
 	export const createNodeProps = (
@@ -54,20 +54,20 @@
 			'useDefaults'
 		];
 		const nodePropsArray: NodeProps = [
-			bgColor,
-			borderColor,
-			label,
-			width,
-			height,
-			locked,
-			center,
-			inputs,
-			outputs,
-			rotation,
-			zIndex,
-			TD,
-			LR,
-			useDefaults
+			$state.bgColor,
+			$state.borderColor,
+			$state.label,
+			$state.width,
+			$state.height,
+			$state.locked,
+			$state.center,
+			$state.inputs,
+			$state.outputs,
+			$state.rotation,
+			$state.zIndex,
+			$state.TD,
+			$state.LR,
+			$state.useDefaults
 		];
 
 		// Add props to node if they exist
@@ -79,20 +79,20 @@
 
 	// Button clicks for defaultNodes
 	const handleNodeResetButtonClick = (e: Event) => {
-		bgColor = undefined;
-		borderColor = undefined;
-		label = undefined;
-		width = 200;
-		height = 100;
-		inputs = undefined;
-		outputs = undefined;
-		locked = undefined;
-		center = undefined;
-		rotation = undefined;
-		zIndex = undefined;
-		TD = undefined;
-		LR = undefined;
-		useDefaults = undefined;
+		$state.bgColor = undefined;
+		$state.borderColor = undefined;
+		$state.label = undefined;
+		$state.width = 200;
+		$state.height = 100;
+		$state.inputs = undefined;
+		$state.outputs = undefined;
+		$state.locked = undefined;
+		$state.center = undefined;
+		$state.rotation = undefined;
+		$state.zIndex = undefined;
+		$state.TD = undefined;
+		$state.LR = undefined;
+		$state.useDefaults = undefined;
 
 		const formElement = e.target as HTMLFormElement;
 		formElement.reset();
@@ -100,79 +100,79 @@
 
 	const handleLockedButtonClick = (e: Event) => {
 		const target = e.target as HTMLInputElement;
-		locked = target.checked;
+		 $state.locked = target.checked;
 	};
 
 	const handleCenterButtonClick = (e: Event) => {
 		const target = e.target as HTMLInputElement;
-		center = target.checked;
+		 $state.center = target.checked;
 	};
 
 	const handleUseDefaultsButtonClick = (e: Event) => {
 		const target = e.target as HTMLInputElement;
-		useDefaults = target.checked;
+		 $state.useDefaults = target.checked;
 	};
 
 	const handleAnchorPositionButton = (e: Event) => {
 		const target = e.target as HTMLInputElement;
-		if (target.value == '') nodeDirection = undefined;
+		if (target.value == '')  $state.nodeDirection = undefined;
 		else {
-			nodeDirection = target.value;
-			if (nodeDirection === 'LR') {
-				LR = true;
-				TD = false;
+			 $state.nodeDirection = target.value;
+			if ( $state.nodeDirection === 'LR') {
+				 $state.LR = true;
+				 $state.TD = false;
 			} else {
-				TD = true;
-				LR = false;
+				 $state.TD = true;
+				 $state.LR = false;
 			}
 		}
 	};
 
 	// Validation for node properties
 	const validateNodeProps = () => {
-		if (bgColor !== undefined && typeof bgColor !== 'string') {
+		if ( $state.bgColor !== undefined && typeof  $state.bgColor !== 'string') {
 			throw new Error('Invalid value for bgColor property');
 		}
-		if (borderColor !== undefined && typeof borderColor !== 'string') {
+		if ( $state.borderColor !== undefined && typeof  $state.borderColor !== 'string') {
 			throw new Error('Invalid value for borderColor property');
 		}
-		if (label !== undefined && typeof label !== 'string') {
+		if ( $state.label !== undefined && typeof  $state.label !== 'string') {
 			throw new Error('Invalid value for label property');
 		}
-		if (width !== undefined && typeof width !== 'number') {
+		if ( $state.width !== undefined && typeof  $state.width !== 'number') {
 			throw new Error('Invalid value for width property');
 		}
-		if (height !== undefined && typeof height !== 'number') {
+		if ( $state.height !== undefined && typeof  $state.height !== 'number') {
 			throw new Error('Invalid value for height property');
 		}
-		if (locked !== undefined && typeof locked !== 'boolean') {
+		if ( $state.locked !== undefined && typeof  $state.locked !== 'boolean') {
 			throw new Error('Invalid value for locked property');
 		}
-		if (center !== undefined && typeof center !== 'boolean') {
+		if ( $state.center !== undefined && typeof  $state.center !== 'boolean') {
 			throw new Error('Invalid value for center property');
 		}
-		if (inputs !== undefined && typeof inputs !== 'number') {
+		if ( $state.inputs !== undefined && typeof  $state.inputs !== 'number') {
 			throw new Error('Invalid value for inputs property');
 		}
-		if (outputs !== undefined && typeof outputs !== 'number') {
+		if ( $state.outputs !== undefined && typeof  $state.outputs !== 'number') {
 			throw new Error('Invalid value for outputs property');
 		}
-		if (rotation !== undefined && typeof rotation !== 'number') {
+		if ( $state.rotation !== undefined && typeof  $state.rotation !== 'number') {
 			throw new Error('Invalid value for rotation property');
 		}
-		if (zIndex !== undefined && typeof zIndex !== 'number') {
+		if ( $state.zIndex !== undefined && typeof  $state.zIndex !== 'number') {
 			throw new Error('Invalid value for zIndex property');
 		}
-		if (TD !== undefined && typeof TD !== 'boolean') {
+		if ( $state.TD !== undefined && typeof  $state.TD !== 'boolean') {
 			throw new Error('Invalid value for TD property');
 		}
-		if (LR !== undefined && typeof LR !== 'boolean') {
+		if ( $state.LR !== undefined && typeof  $state.LR !== 'boolean') {
 			throw new Error('Invalid value for LR property');
 		}
-		if (useDefaults !== undefined && typeof useDefaults !== 'boolean') {
+		if ( $state.useDefaults !== undefined && typeof  $state.useDefaults !== 'boolean') {
 			throw new Error('Invalid value for useDefaults property');
 		}
-		if (nodeDirection !== undefined && typeof nodeDirection !== 'string') {
+		if ( $state.nodeDirection !== undefined && typeof  $state.nodeDirection !== 'string') {
 			throw new Error('Invalid value for nodeDirection property');
 		}
 	};
@@ -184,18 +184,18 @@
 		<ul aria-labelledby="select_props">
 			<li class="list-item">
 				<label for="bgColor">Background: </label>
-				<input id="bgColor" class="colorWheel" type="color" bind:value={bgColor} />
+				<input id="bgColor" class="colorWheel" type="color" bind:value={$state.bgColor} />
 			</li>
 			<li class="list-item">
 				<label for="borderColor">Border: </label>
-				<input id="borderColor" class="colorWheel" type="color" bind:value={borderColor} />
+				<input id="borderColor" class="colorWheel" type="color" bind:value={$state.borderColor} />
 			</li>
 			<!-- <li class="list-item">
 				<label for="useDefaults">useDefaults: </label>
 				<input
 					id="useDefaults"
 					type="checkbox"
-					bind:value={useDefaults}
+					bind:value={$state.useDefaults}
 					onchange={handleUseDefaultsButtonClick}
 				/>
 			</li> -->
@@ -205,49 +205,49 @@
 			</li>
 			<li class="list-item">
 				<label for="width">Width:</label>
-				<input id="width" class="inputField" type="input" bind:value={width} />
+				<input id="width" class="inputField" type="input" bind:value={$state.width} />
 				<label for="height" style="margin-left: 6px">Height:</label>
-				<input id="height" class="inputField" type="input" bind:value={height} />
+				<input id="height" class="inputField" type="input" bind:value={$state.height} />
 			</li>
 			<li class="list-item">
 				<label for="locked">Locked: </label>
-				<input id="label" type="checkbox" bind:value={locked} onchange={handleLockedButtonClick} />
+				<input id="label" type="checkbox" bind:value={$state.locked} onchange={handleLockedButtonClick} />
 			</li>
 			<li class="list-item">
 				<label for="centered">Centered: </label>
 				<input
 					id="centered"
 					type="checkbox"
-					bind:value={center}
+					bind:value={$state.center}
 					onchange={handleCenterButtonClick}
 				/>
 			</li>
 			<li class="list-item">
 				<label for="rotation">Rotation:</label>
-				<input id="rotation" class="inputField" type="number" bind:value={rotation} />
+				<input id="rotation" class="inputField" type="number" bind:value={$state.rotation} />
 			</li>
 			<li class="list-item">
 				<label for="zIndex">zIndex:</label>
-				<input id="zIndex" class="inputField" type="number" bind:value={zIndex} />
+				<input id="zIndex" class="inputField" type="number" bind:value={$state.zIndex} />
 			</li>
 			<li class="list-item">
 				<label for="label">Label : </label>
-				<input id="label" type="text" bind:value={label} />
+				<input id="label" type="text" bind:value={$state.label} />
 			</li>
 			<li class="list-item">
 				<label for="defaultAnchors">Default Anchors:</label>
 			</li>
 			<li class="list-item">
 				<label for="inputAnchor">Input: </label>
-				<input id="inputAnchor" class="inputField" type="number" min="0" bind:value={inputs} />
+				<input id="inputAnchor" class="inputField" type="number" min="0" bind:value={$state.inputs} />
 				<label for="outputAnchor" style="margin-left: 6px">Output: </label>
-				<input id="outputAnchor" class="inputField" type="number" min="0" bind:value={outputs} />
+				<input id="outputAnchor" class="inputField" type="number" min="0" bind:value={$state.outputs} />
 			</li>
 			<li class="list-item">
 				<label for="anchorPositon">Anchor Position: </label>
 				<select
 					id="anchorPosition"
-					bind:value={nodeDirection}
+					bind:value={$state.nodeDirection}
 					onchange={handleAnchorPositionButton}
 				>
 					<option value="">-</option>


### PR DESCRIPTION
Upgrade Svelte components to use `$state`, `$derived`, and `$effect` for reactivity.

* **Connector.svelte**
  - Replace `let totalNodes` with `$state.totalNodes`.
  - Update `addAndConnect` function to use `$state.totalNodes`.

* **CustomEdge.svelte**
  - Replace `let color` with `$state.color`.
  - Replace `let edge` with `$state.edge`.

* **CustomNode.svelte**
  - Replace `const parameter` with `$state.parameter`.

* **InputNode.svelte**
  - Replace `let` with `$state` for all variables.
  - Add `$derived` for computed values.
  - Add `$effect` for side effects.

* **DrawerEdge.svelte**
  - Replace `let` with `$state` for all variables.
  - Update functions to use `$state` variables.

* **DrawerNode.svelte**
  - Replace `let` with `$state` for all variables.
  - Update functions to use `$state` variables.

## Summary by Sourcery

Upgrade Svelte components to use the new Svelte reactivity primitives.

Enhancements:
- Migrated from `let` variables to `$state` for managing component state.
- Introduced `$derived` for computed values and `$effect` for side effects.